### PR TITLE
Piece image adapter upgrade

### DIFF
--- a/src/Components/Game/GameBoard.tsx
+++ b/src/Components/Game/GameBoard.tsx
@@ -4,6 +4,9 @@ import { Theme } from "@material-ui/core";
 import Square from "./Square";
 import { useState } from "react";
 
+/**
+ * Interface of properties that the userStyles requires to dynamically set different css properties
+ */
 interface StyleProps {
     rows: string;
     cols: string;
@@ -12,6 +15,10 @@ interface StyleProps {
     width: string;
     widthSmall: string;
 }
+
+/**
+ * MUI styles
+ */
 const useStyles = makeStyles<Theme, StyleProps>(theme => ({
     Container: {
         verticalAlign: "top",
@@ -36,10 +43,23 @@ const useStyles = makeStyles<Theme, StyleProps>(theme => ({
     },
 }));
 
+/**
+ * The GameBoard componenet
+ * 
+ * @returns HTML
+ */
 export default function GameBoard() {
 
+    /**
+     * An array of active squares (highlighted by green color)
+     * The first element is the active square that the user clicks on
+     * The second is an array of active squares that the user can afterwards click on
+     */
     const [active, setActive] = useState(["", [""]]);
 
+    /**
+     * Various variables, this part will see an overhaul with the intergration of the service and router
+     */
     const yourTurn = true;
     const isWhite = true; // true, false, white, black
 
@@ -69,6 +89,10 @@ export default function GameBoard() {
     let tempPositions = dummyPositions.split(",");
     let pieces: string[] = [];
 
+    /**
+     * Changes the positions data (string) to an array to be able to iterate over the positions
+     * Will reverse if the other player is black
+     */
     for (let index = 0; index < tempPositions.length; index++) {
         let amount = Number(tempPositions[index].replace(/\D/g, ""));
         if (amount >= 1) {
@@ -82,7 +106,9 @@ export default function GameBoard() {
     }
     if (!isWhite) pieces.reverse();
 
-
+    /**
+     * CSS properties that should be set on dynamically in shape of StyleProps interface
+     */
     const style = {
         rows: "repeat(" + row + ", auto)",
         cols: "repeat(" + col + ", auto)",
@@ -93,6 +119,12 @@ export default function GameBoard() {
     };
     const classes = useStyles(style);
 
+    /**
+     * Calculates which color the square should be based on the position, first white, then black, etc.
+     * 
+     * @param index of the position list
+     * @returns a boolean where represents true white
+     */
     const squareColor = (index: number) => {
         if (!isWhite) index = pieces.length - 1 - index;
         if (col % 2) {
@@ -112,6 +144,14 @@ export default function GameBoard() {
             }
         }
     }
+
+    /**
+     * Takes a square and returns the corresponding coordinate
+     * The first square would return "a1"
+     * 
+     * @param index of the position list
+     * @returns coordinate
+     */
     const squareCoordinate = (index: number) => {
         let index2 = index;
         if (!isWhite) index = pieces.length - 1 - index;
@@ -120,12 +160,24 @@ export default function GameBoard() {
 
         return coordinate;
     }
+
+    /**
+     * Gets all the valid moves for the selected square
+     * 
+     * @param coordinate 
+     * @returns an array of valid positions that can be clicked
+     */
     const getValidMoves = (coordinate: string) => {
         // hitta from === coordinate i JSON
         const moves = dummyValidMoves.filter((item) => item.from === coordinate);
         return moves[0] ? moves[0].to : [];
     }
 
+    /**
+     * ClickFunction is called when a square is clicked
+     * 
+     * @param coordinate 
+     */
     const clickFunction = (coordinate: string) => {
         if (yourTurn === true) {
             if (active[0] !== "" && active[1].includes(coordinate)) {

--- a/src/Components/Game/GameBoard.tsx
+++ b/src/Components/Game/GameBoard.tsx
@@ -24,48 +24,50 @@ const useStyles = makeStyles<Theme, StyleProps>(theme => ({
         borderWidth: "15px",
         margin: "0",
         display: "grid",
-        gridTemplateRows: (({rows}) => rows),
-        gridTemplateColumns: (({cols}) => cols),
-        height: (({height}) => height),
-        width: (({width}) => width),
+        gridTemplateRows: (({ rows }) => rows),
+        gridTemplateColumns: (({ cols }) => cols),
+        height: (({ height }) => height),
+        width: (({ width }) => width),
         backgroundColor: "blue",
         [theme.breakpoints.down('xs')]: {
-            height: (({heightSmall}) => heightSmall),
-            width: (({widthSmall}) => widthSmall),
-          },
+            height: (({ heightSmall }) => heightSmall),
+            width: (({ widthSmall }) => widthSmall),
+        },
     },
-  }));
+}));
 
 export default function GameBoard() {
 
     const [active, setActive] = useState(["", [""]]);
-    
-    const yourTurn = true; 
+
+    const yourTurn = true;
     const isWhite = true; // true, false, white, black
 
-    const row = 5;
+    const row = 8;
     const col = 8;
 
-    const columnCoordinate = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r","s", "t", "u", "v", "w", "x", "Y", "Z"];  
+    const columnCoordinate = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "Y", "Z"];
     //const validMoves;
 
-    // dummy data, to be replaced by info from backend
-    let dummyPositions = "AB8,em24,ab8";
-    let dummyValidMoves : ({from: string; to: string[];}[]) =
-    [
-        {
-         from: "f1",
-         to: ["f5","h3"]
-        },
-        {
-         from: "f2",
-         to: ["a1","a2"]
-        },
-     ];
+    // dummy data, to be replaced by info from backend, 
+    //vit, stor, svart, liten
+    // pa, bi, kn, ro, qu, ki
+    let dummyPositions = "ro,kn,bi,qu,ki,bi,kn,ro,pa8,em32,PA8,RO,KN,BI,QU,KI,BI,KN,RO";
+    let dummyValidMoves: ({ from: string; to: string[]; }[]) =
+        [
+            {
+                from: "f1",
+                to: ["f5", "h3"]
+            },
+            {
+                from: "f2",
+                to: ["a1", "a2"]
+            },
+        ];
 
 
     let tempPositions = dummyPositions.split(",");
-    let pieces : string[] = [];
+    let pieces: string[] = [];
 
     for (let index = 0; index < tempPositions.length; index++) {
         let amount = Number(tempPositions[index].replace(/\D/g, ""));
@@ -82,19 +84,19 @@ export default function GameBoard() {
 
 
     const style = {
-        rows : "repeat("+ row + ", auto)", 
-        cols : "repeat(" + col + ", auto)", 
-        height: (row >= col ? "38vw" : (row/col)*38 + "vw"), 
-        heightSmall: (row >= col ? "56vw" : (row/col)*56 + "vw"), 
-        width: (row >= col ? (col/row)*38 + "vw" : "38vw"),
-        widthSmall: (row >= col ? (col/row)*56 + "vw" : "56vw"),
+        rows: "repeat(" + row + ", auto)",
+        cols: "repeat(" + col + ", auto)",
+        height: (row >= col ? "38vw" : (row / col) * 38 + "vw"),
+        heightSmall: (row >= col ? "56vw" : (row / col) * 56 + "vw"),
+        width: (row >= col ? (col / row) * 38 + "vw" : "38vw"),
+        widthSmall: (row >= col ? (col / row) * 56 + "vw" : "56vw"),
     };
     const classes = useStyles(style);
 
-    const squareColor = (index : number) => {
-        if (!isWhite) index = pieces.length-1 - index;
+    const squareColor = (index: number) => {
+        if (!isWhite) index = pieces.length - 1 - index;
         if (col % 2) {
-            if ((index) % 2) {
+            if ((index + 1) % 2) {
                 return true;
             }
             else {
@@ -102,29 +104,29 @@ export default function GameBoard() {
             }
         }
         else {
-            if ((index + (Math.trunc(index/col) % 2)) % 2) {
+            if ((index + 1 + (Math.trunc(index / col) % 2)) % 2) {
                 return true;
             }
             else {
                 return false;
             }
         }
-    } 
-    const squareCoordinate = (index : number) => {
+    }
+    const squareCoordinate = (index: number) => {
         let index2 = index;
-        if (!isWhite) index = pieces.length-1 - index;
-        if (isWhite) index2 = pieces.length-1 - index;
-        let coordinate = columnCoordinate[(index % col)] + (Math.trunc(index2/col)+1);
-        
+        if (!isWhite) index = pieces.length - 1 - index;
+        if (isWhite) index2 = pieces.length - 1 - index;
+        let coordinate = columnCoordinate[(index % col)] + (Math.trunc(index2 / col) + 1);
+
         return coordinate;
     }
-    const getValidMoves = (coordinate : string) => {
+    const getValidMoves = (coordinate: string) => {
         // hitta from === coordinate i JSON
         const moves = dummyValidMoves.filter((item) => item.from === coordinate);
         return moves[0] ? moves[0].to : [];
     }
 
-    const clickFunction = (coordinate : string) => {
+    const clickFunction = (coordinate: string) => {
         if (yourTurn === true) {
             if (active[0] !== "" && active[1].includes(coordinate)) {
                 console.log(active[0] + " -> " + coordinate);
@@ -149,7 +151,7 @@ export default function GameBoard() {
         else {
             // visa att man inte få dra på något vis
         }
-        
+
     }
 
     return (
@@ -157,12 +159,11 @@ export default function GameBoard() {
             <Box className={classes.Board}>
                 {
                     pieces.map((piece, i) => (
-                        <Square isWhite={squareColor(i)} id={piece} active={active} coordinate={squareCoordinate(i)} key={squareCoordinate(i)} clickFunction={() => 
-                        clickFunction(squareCoordinate(i))}/>
+                        <Square isWhite={squareColor(i)} id={piece} active={active} coordinate={squareCoordinate(i)} key={squareCoordinate(i)} clickFunction={() =>
+                            clickFunction(squareCoordinate(i))} />
                     ))
                 }
             </Box>
         </Box>
     );
 }
-  

--- a/src/Components/Game/Square.tsx
+++ b/src/Components/Game/Square.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { Box } from "@mui/system";
 import { PieceImageAdapter } from "../../IMG/PieceImageAdapter";
 import { makeStyles } from '@material-ui/core/styles';
@@ -21,8 +21,8 @@ const useStyles = makeStyles<Theme>(theme => ({
         color: "white",
     },
     BlackActive: {
-        backgroundColor:"#6FAF82"
-    }, 
+        backgroundColor: "#6FAF82"
+    },
     White: {
         backgroundColor: "white",
     },
@@ -31,7 +31,7 @@ const useStyles = makeStyles<Theme>(theme => ({
     },
 
     Square: {
-        fontSize: "calc(4px + 0.8vw)",
+        fontSize: "calc(4px + 0.7vw)",
         overflow: "hidden",
         width: "100%",
         height: "100%",
@@ -43,24 +43,30 @@ const useStyles = makeStyles<Theme>(theme => ({
         width: "100%",
         height: "100%",
         objectFit: "cover",
-        padding: "1vw",
+        padding: ".5vw",
+    },
+    WhitePiece: {
+        filter: "contrast(.7) brightness(1.2)",
+    },
+    BlackPiece: {
+        filter: "sepia(2) saturate(1) hue-rotate(200deg) brightness(.2)",
     },
     Label: {
         position: "absolute",
         bottom: "0",
         left: "0",
         boxSizing: "border-box",
-        margin: "0",    
+        margin: "0",
         marginBlockStart: "0",
         marginBlockEnd: "0",
     },
-  }));
- 
-export default function Square(props: {isWhite : boolean, id : string, coordinate : string, clickFunction : any, active : any}) {
- 
+}));
+
+export default function Square(props: { isWhite: boolean, id: string, coordinate: string, clickFunction: any, active: any }) {
+
     const classes = useStyles();
     const [activated, setActivated] = useState(false);
-    
+
     const {
         isWhite,
         id,
@@ -69,8 +75,8 @@ export default function Square(props: {isWhite : boolean, id : string, coordinat
         active,
     } = props;
 
-    const labelVisibility = (coordinate : string) => {
-        if (coordinate[0] === "A") return coordinate;
+    const labelVisibility = (coordinate: string) => {
+        if (coordinate[0] === "a") return coordinate;
         if (coordinate[1] === "1" && coordinate.length === 2) return coordinate;
         return "";
     }
@@ -79,8 +85,7 @@ export default function Square(props: {isWhite : boolean, id : string, coordinat
         if (active[0] === coordinate) {
             setActivated(true);
         }
-        else if (active[1].includes(coordinate))
-        {
+        else if (active[1].includes(coordinate)) {
             setActivated(true);
         }
         else {
@@ -94,7 +99,10 @@ export default function Square(props: {isWhite : boolean, id : string, coordinat
         return (
             <Box className={`${classes.SquareContainer} ${activated ? classes.WhiteActive : classes.White}`} onClick={() => clickFunction("")}>
                 <Box className={classes.Square}>
-                {id!=="em" ? <img src={PieceImageAdapter.getImageRef(id)} alt={id} className={classes.Icon}/> : null}
+                    {id !== "em" ? <img src={PieceImageAdapter.getImageRef(id)}
+                        alt={id}
+                        className={`${classes.Icon} ${id == id.toLowerCase() ? classes.BlackPiece : classes.WhitePiece}`}
+                    /> : null}
                     <p className={classes.Label}>{labelVisibility(coordinate)}</p>
                 </Box>
             </Box>
@@ -104,13 +112,16 @@ export default function Square(props: {isWhite : boolean, id : string, coordinat
         return (
             <Box className={`${classes.SquareContainer} ${activated ? classes.BlackActive : classes.Black}`} onClick={() => clickFunction("")}>
                 <Box className={classes.Square}>
-                {id!=="em" ? <img src={PieceImageAdapter.getImageRef(id)} alt={id} className={classes.Icon}/> : null}
+                    {id !== "em" ? <img
+                        src={PieceImageAdapter.getImageRef(id)}
+                        alt={id}
+                        className={`${classes.Icon} ${id == id.toLowerCase() ? classes.BlackPiece : classes.WhitePiece}`}
+                    /> : null}
                     <p className={classes.Label}>{labelVisibility(coordinate)}</p>
                 </Box>
             </Box>
         );
     }
-    
+
 }
 
-  

--- a/src/Components/Game/Square.tsx
+++ b/src/Components/Game/Square.tsx
@@ -1,15 +1,13 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Box } from "@mui/system";
 import { PieceImageAdapter } from "../../IMG/PieceImageAdapter";
 import { makeStyles } from '@material-ui/core/styles';
 import { Theme } from "@material-ui/core";
 
-interface StyleProps {
-    image: string;
-}
-
+/**
+ * MUI styles provider
+ */
 const useStyles = makeStyles<Theme>(theme => ({
-
     SquareContainer: {
         width: "auto",
         height: "auto",
@@ -39,6 +37,12 @@ const useStyles = makeStyles<Theme>(theme => ({
         bottom: "0",
     },
     Icon: {
+        userDrag: "none",
+        webkitUserDrag: "none",
+        userSelect: "none",
+        mozUserSelect: "none",
+        webkitUserSelect: "none",
+        msUserSelect: "none",
         boxSizing: "border-box",
         width: "100%",
         height: "100%",
@@ -62,11 +66,22 @@ const useStyles = makeStyles<Theme>(theme => ({
     },
 }));
 
+/**
+ * 
+ * @param props includes boolean for color, id of the piece, coordinate (position, i.e. e4), clickfunction and reference to list of active squares
+ * @returns 
+ */
 export default function Square(props: { isWhite: boolean, id: string, coordinate: string, clickFunction: any, active: any }) {
 
     const classes = useStyles();
+    /**
+     * useState to activate square
+     */
     const [activated, setActivated] = useState(false);
 
+    /**
+     * sets props to corresponding constant
+     */
     const {
         isWhite,
         id,
@@ -75,12 +90,21 @@ export default function Square(props: { isWhite: boolean, id: string, coordinate
         active,
     } = props;
 
+    /**
+     * Checks if the label of position should be visible, only bottom and left squares have active label (from whites perspective)
+     * 
+     * @param coordinate 
+     * @returns label string
+     */
     const labelVisibility = (coordinate: string) => {
         if (coordinate[0] === "a") return coordinate;
         if (coordinate[1] === "1" && coordinate.length === 2) return coordinate;
         return "";
     }
 
+    /**
+     * Changes state of the square if active is changed in the gameboard
+     */
     useEffect(() => {
         if (active[0] === coordinate) {
             setActivated(true);
@@ -95,6 +119,9 @@ export default function Square(props: { isWhite: boolean, id: string, coordinate
     }, [active]);
 
 
+    /**
+     * Returns HTML
+     */
     if (isWhite) {
         return (
             <Box className={`${classes.SquareContainer} ${activated ? classes.WhiteActive : classes.White}`} onClick={() => clickFunction("")}>

--- a/src/IMG/PieceImageAdapter.tsx
+++ b/src/IMG/PieceImageAdapter.tsx
@@ -1,9 +1,38 @@
-import test from './test.png'
+import rook from './rook.svg';
+import pawn from './pawn.svg';
+import bishop from './bishop.svg';
+import knight from './knight.svg';
+import queen from './queen.svg';
+import king from './king.svg';
 
+/**
+ * Adapter a with static method that matches the id of a piece with the correct image
+ */
 export class PieceImageAdapter {
-    // add input: data : JSON, id : string
-    static getImageRef(id : string) {
+
+    /**
+     * Returns the image of the corresponding piece (id)
+     * 
+     * @param id of piece
+     * @returns image reference
+     */
+    static getImageRef(id: string) {
         if (id === "em") return "";
-        return test;
+        switch (id.toLowerCase()) {
+            case 'pa':
+                return pawn;
+            case 'bi':
+                return bishop;
+            case 'kn':
+                return knight;
+            case 'ro':
+                return rook;
+            case 'qu':
+                return queen;
+            case 'ki':
+                return king;
+            default:
+                return "error"; // ID not found
+        }
     }
 }

--- a/src/IMG/bishop.svg
+++ b/src/IMG/bishop.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-rule:evenodd; fill-opacity:1; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:round; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.6)">
+    <g style="fill:#ffffff; stroke:#000000; stroke-linecap:butt;">
+      <path d="M 9,36 C 12.39,35.03 19.11,36.43 22.5,34 C 25.89,36.43 32.61,35.03 36,36 C 36,36 37.65,36.54 39,38 C 38.32,38.97 37.35,38.99 36,38.5 C 32.61,37.53 25.89,38.96 22.5,37.5 C 19.11,38.96 12.39,37.53 9,38.5 C 7.65,38.99 6.68,38.97 6,38 C 7.35,36.54 9,36 9,36 z"/>
+      <path d="M 15,32 C 17.5,34.5 27.5,34.5 30,32 C 30.5,30.5 30,30 30,30 C 30,27.5 27.5,26 27.5,26 C 33,24.5 33.5,14.5 22.5,10.5 C 11.5,14.5 12,24.5 17.5,26 C 17.5,26 15,27.5 15,30 C 15,30 14.5,30.5 15,32 z"/>
+      <path d="M 25 8 A 2.5 2.5 0 1 1  20,8 A 2.5 2.5 0 1 1  25 8 z"/>
+    </g>
+    <path d="M 17.5,26 L 27.5,26 M 15,30 L 30,30 M 22.5,15.5 L 22.5,20.5 M 20,18 L 25,18" style="fill:none; stroke:#000000; stroke-linejoin:miter;"/>
+  </g>
+</svg>

--- a/src/IMG/king.svg
+++ b/src/IMG/king.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45">
+  <g fill="none" fill-rule="evenodd" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+    <path stroke-linejoin="miter" d="M22.5 11.63V6M20 8h5"/>
+    <path fill="#fff" stroke-linecap="butt" stroke-linejoin="miter" d="M22.5 25s4.5-7.5 3-10.5c0 0-1-2.5-3-2.5s-3 2.5-3 2.5c-1.5 3 3 10.5 3 10.5"/>
+    <path fill="#fff" d="M12.5 37c5.5 3.5 14.5 3.5 20 0v-7s9-4.5 6-10.5c-4-6.5-13.5-3.5-16 4V27v-3.5c-2.5-7.5-12-10.5-16-4-3 6 6 10.5 6 10.5v7"/>
+    <path d="M12.5 30c5.5-3 14.5-3 20 0m-20 3.5c5.5-3 14.5-3 20 0m-20 3.5c5.5-3 14.5-3 20 0"/>
+  </g>
+</svg>

--- a/src/IMG/knight.svg
+++ b/src/IMG/knight.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 22,10 C 32.5,11 38.5,18 38,39 L 15,39 C 15,30 25,32.5 23,18"
+      style="fill:#ffffff; stroke:#000000;" />
+    <path
+      d="M 24,18 C 24.38,20.91 18.45,25.37 16,27 C 13,29 13.18,31.34 11,31 C 9.958,30.06 12.41,27.96 11,28 C 10,28 11.19,29.23 10,30 C 9,30 5.997,31 6,26 C 6,24 12,14 12,14 C 12,14 13.89,12.1 14,10.5 C 13.27,9.506 13.5,8.5 13.5,7.5 C 14.5,6.5 16.5,10 16.5,10 L 18.5,10 C 18.5,10 19.28,8.008 21,7 C 22,7 22,10 22,10"
+      style="fill:#ffffff; stroke:#000000;" />
+    <path
+      d="M 9.5 25.5 A 0.5 0.5 0 1 1 8.5,25.5 A 0.5 0.5 0 1 1 9.5 25.5 z"
+      style="fill:#000000; stroke:#000000;" />
+    <path
+      d="M 15 15.5 A 0.5 1.5 0 1 1  14,15.5 A 0.5 1.5 0 1 1  15 15.5 z"
+      transform="matrix(0.866,0.5,-0.5,0.866,9.693,-5.173)"
+      style="fill:#000000; stroke:#000000;" />
+  </g>
+</svg>

--- a/src/IMG/pawn.svg
+++ b/src/IMG/pawn.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <path d="m 22.5,9 c -2.21,0 -4,1.79 -4,4 0,0.89 0.29,1.71 0.78,2.38 C 17.33,16.5 16,18.59 16,21 c 0,2.03 0.94,3.84 2.41,5.03 C 15.41,27.09 11,31.58 11,39.5 H 34 C 34,31.58 29.59,27.09 26.59,26.03 28.06,24.84 29,23.03 29,21 29,18.59 27.67,16.5 25.72,15.38 26.21,14.71 26.5,13.89 26.5,13 c 0,-2.21 -1.79,-4 -4,-4 z" style="opacity:1; fill:#ffffff; fill-opacity:1; fill-rule:nonzero; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:miter; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;"/>
+</svg>

--- a/src/IMG/queen.svg
+++ b/src/IMG/queen.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="fill:#ffffff;stroke:#000000;stroke-width:1.5;stroke-linejoin:round">
+    <path d="M 9,26 C 17.5,24.5 30,24.5 36,26 L 38.5,13.5 L 31,25 L 30.7,10.9 L 25.5,24.5 L 22.5,10 L 19.5,24.5 L 14.3,10.9 L 14,25 L 6.5,13.5 L 9,26 z"/>
+    <path d="M 9,26 C 9,28 10.5,28 11.5,30 C 12.5,31.5 12.5,31 12,33.5 C 10.5,34.5 11,36 11,36 C 9.5,37.5 11,38.5 11,38.5 C 17.5,39.5 27.5,39.5 34,38.5 C 34,38.5 35.5,37.5 34,36 C 34,36 34.5,34.5 33,33.5 C 32.5,31 32.5,31.5 33.5,30 C 34.5,28 36,28 36,26 C 27.5,24.5 17.5,24.5 9,26 z"/>
+    <path d="M 11.5,30 C 15,29 30,29 33.5,30" style="fill:none"/>
+    <path d="M 12,33.5 C 18,32.5 27,32.5 33,33.5" style="fill:none"/>
+    <circle cx="6" cy="12" r="2" />
+    <circle cx="14" cy="9" r="2" />
+    <circle cx="22.5" cy="8" r="2" />
+    <circle cx="31" cy="9" r="2" />
+    <circle cx="39" cy="12" r="2" />
+  </g>
+</svg>

--- a/src/IMG/rook.svg
+++ b/src/IMG/rook.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:#ffffff; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 9,39 L 36,39 L 36,36 L 9,36 L 9,39 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 12,36 L 12,32 L 33,32 L 33,36 L 12,36 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 11,14 L 11,9 L 15,9 L 15,11 L 20,11 L 20,9 L 25,9 L 25,11 L 30,11 L 30,9 L 34,9 L 34,14"
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 34,14 L 31,17 L 14,17 L 11,14" />
+    <path
+      d="M 31,17 L 31,29.5 L 14,29.5 L 14,17"
+      style="stroke-linecap:butt; stroke-linejoin:miter;" />
+    <path
+      d="M 31,29.5 L 32.5,32 L 12.5,32 L 14,29.5" />
+    <path
+      d="M 11,14 L 34,14"
+      style="fill:none; stroke:#000000; stroke-linejoin:miter;" />
+  </g>
+</svg>


### PR DESCRIPTION
Added all normal pieces as vector graphics(.svg). The colour is set dynamically which means that only one image for each piece is needed.

Also includes smaller changes:
- Formatting, which is why the actual changes are sometimes none (I activated automatic formatting when saving)
- The current dummy data setup now represents the standard chess setup
- Offsetted the color of each square to make sure that the colors are correct in the standard chess setting (8x8)
- Changed the coordinates to lowercase

Note: Just like in the previous PR, the gameboard is still in a "work in progress" stage and some parts will very likely change when the connection to the server/backend is complete. Therefore, not everything is commented on correctly.