### PR TITLE
Lobby and game now supports playing vs AI

### DIFF
--- a/src/Services/GameService.ts
+++ b/src/Services/GameService.ts
@@ -130,6 +130,10 @@ export default class GameService {
         this.hubConnection.send('SwapColors', gameId);
     }
 
+    sendAddAI(gameId: string): void {
+        this.hubConnection.send('AssignAI', gameId);
+    }
+
     async requestColors(gameId: string): Promise<Colors> {
         return this.hubConnection.invoke('RequestColors', gameId)
     }


### PR DESCRIPTION
**Merge this after [this PR](https://github.com/ChessVariants/ChessVariantsAPI/pull/26) as that contains the backend functionality required.**

Pretty basic stuff! I've added a method in `GameService` for sending a request to the backend to add an AI to the game. Additionally the lobby now has a "Add AI" button which is available only when the lobby is not full.

This PR should be merged after https://github.com/ChessVariants/chess-variants-frontend/pull/7 since that PR changes the lobby somewhat, so I'll adjust these changes accordingly.