### PR TITLE
Full promotion added

### DIFF
--- a/src/Components/Game/GameBoard.tsx
+++ b/src/Components/Game/GameBoard.tsx
@@ -74,7 +74,7 @@ export default function GameBoard(props: { gameID: string, color: string }) {
     /**
      * GameState which includes boardsize, positions, side to move and valid moves.
      */
-    const [gameState, setGameState] = useState<GameState>(initialState);    
+    const [gameState, setGameState] = useState<GameState>(initialState);
 
     /**
      * The GameBoard requires the GameService object as a prop
@@ -228,13 +228,28 @@ export default function GameBoard(props: { gameID: string, color: string }) {
 
     }
 
+    const shouldHighlight = (index: number) => {
+        if (color === "black" && gameState.latestMoveFromIndex && gameState.latestMoveToIndex) {
+            let boardSize = gameState.boardSize.rows * gameState.boardSize.cols
+            let newFromIndex = boardSize - gameState.latestMoveFromIndex - 1;
+            let newToIndex = boardSize - gameState.latestMoveToIndex - 1;
+            return index === newFromIndex || index === newToIndex;
+        }
+        return index === gameState.latestMoveFromIndex || index === gameState.latestMoveToIndex;
+    }
+
     return (
         <Box className={classes.Container}>
             <Box className={classes.Board}>
                 {
                     pieces.map((piece, i) => (
-                        <Square isWhite={squareColor(i)} id={piece} active={active} coordinate={squareCoordinate(i)} key={squareCoordinate(i)} clickFunction={() =>
-                            clickFunction(squareCoordinate(i))} />
+                        <Square
+                        isWhite={squareColor(i)}
+                        id={piece} active={active}
+                        coordinate={squareCoordinate(i)}
+                        key={squareCoordinate(i)}
+                        clickFunction={() => clickFunction(squareCoordinate(i))}
+                        highlight={shouldHighlight(i)} />
                     ))
                 }
             </Box>

--- a/src/Components/Game/MatchPage.tsx
+++ b/src/Components/Game/MatchPage.tsx
@@ -3,11 +3,12 @@ import GameBoard from "./GameBoard";
 import GameSideInfo from "./GameSideInfo";
 import { Theme } from "@material-ui/core";
 import { makeStyles } from '@material-ui/core/styles';
-import GameService, { GameEvents, JoinResult } from "../../Services/GameService";
+import GameService, { GameEvents, JoinResult, PromotionOptions } from "../../Services/GameService";
 import { useLocation, useParams } from "react-router-dom";
 import RedirectLogin from "../Util/RedirectLoginPage";
 import { useEffect, useState } from "react";
 import EndScreen from "./EndScreen";
+import PromotionSelector from "./PromotionSelector";
 
 export enum Result {
   ongoing = "Match is ongoing",
@@ -43,6 +44,7 @@ export default function MatchPage() {
   let players = location.state?.players;
 
   const [gameResult, setGameResult] = useState(Result.ongoing);
+  const [promotionOptions, setPromotionOptions] = useState<PromotionOptions | null>(null);
 
 
   useEffect(() => {
@@ -88,6 +90,16 @@ export default function MatchPage() {
         console.log(e);
         setJoinState(JoinState.Fail)
       })
+
+    gameService.on(GameEvents.Promotion, (promotionOptions: PromotionOptions) => {
+      console.log(promotionOptions);
+      setPromotionOptions(promotionOptions);
+    })
+
+    gameService.on(GameEvents.Promoted, () => {
+      console.log('promtion done');
+      setPromotionOptions(null);
+    })
   }, [])
 
   if (gameService.isDisconnected()) {
@@ -109,6 +121,7 @@ export default function MatchPage() {
       {gameResult === Result.ongoing ? null : <EndScreen players={players} result={gameResult} />}
       <Box className={classes.Container}>
         <GameBoard gameID={gameID + ""} color={location.state?.color}></GameBoard>
+        {promotionOptions ? <PromotionSelector options={promotionOptions} gameId={gameID!} /> : null}
         <GameSideInfo gameService={gameService}></GameSideInfo>
       </Box>
     </div>

--- a/src/Components/Game/PromotionSelector.tsx
+++ b/src/Components/Game/PromotionSelector.tsx
@@ -1,0 +1,81 @@
+import { Box } from "@mui/material";
+import GameService, { PromotionOptions } from "../../Services/GameService";
+import Square, { useStyles } from "./Square";
+import { PieceImageAdapter } from "../../IMG/PieceImageAdapter";
+import { makeStyles, Theme } from "@material-ui/core";
+
+export const usePromotionStyle = makeStyles<Theme>(theme => ({
+    BlackSquare: {
+        width: "40px",
+        height: "40px",
+        position: "relative",
+        backgroundColor: "black",
+        '&:hover': {
+            background: "#4d4d4d",
+            cursor: "pointer",
+        },
+    },
+    WhiteSquare: {
+        width: "40px",
+        height: "40px",
+        position: "relative",
+        backgroundColor: "white",
+        '&:hover': {
+            background: "#bfbfbf",
+            cursor: "pointer",
+        },
+    },
+    Container: {
+        display: "inline-block",
+        marginLeft: "20px",
+        width: "14vw",
+        minWidth: "120px",
+        height: "36vw",
+        minHeight: "320px",
+        margin: "0",
+        [theme.breakpoints.down('xs')]: {
+            display: "block",
+            marginLeft: "auto",
+            marginRight: "auto",
+            minWidth: "200px",
+            minHeight: "280px",
+        },
+    },
+
+}));
+
+export default function PromotionSelector(props: { options: PromotionOptions, gameId: string }) {
+    
+    const { options, gameId } = props;
+    const squareClasses = usePromotionStyle();
+
+
+    const choosePromotion = (pieceIdentifier: string) => {
+        GameService.getInstance().sendPromotionChoice(gameId, pieceIdentifier);
+    }
+
+    return (
+        <Box className={squareClasses.Container}>
+            {
+                options.promotablePieces.map((piece, i) => (<PromotionSquare id={piece} key={i} clickFunction={() => choosePromotion(piece)} />))
+            }
+        </Box>
+    );
+}
+
+function PromotionSquare(props: {id: string, clickFunction: any} ) {
+    const { id, clickFunction } = props;
+    const classes = useStyles();
+    const squareClasses = usePromotionStyle();
+
+    return (
+        <Box className={id === id.toLowerCase() ? squareClasses.WhiteSquare : squareClasses.BlackSquare} onClick={() => clickFunction()}>
+            <Box className={classes.Square}>
+                <img src={PieceImageAdapter.getImageRef(id)}
+                    alt={id}
+                    className={`${classes.Icon} ${id == id.toLowerCase() ? classes.BlackPiece : classes.WhitePiece}`}
+                />
+            </Box>
+        </Box>
+    );
+}

--- a/src/Components/Game/Square.tsx
+++ b/src/Components/Game/Square.tsx
@@ -7,7 +7,7 @@ import { Theme } from "@material-ui/core";
 /**
  * MUI styles provider
  */
-const useStyles = makeStyles<Theme>(theme => ({
+export const useStyles = makeStyles<Theme>(theme => ({
     SquareContainer: {
         width: "auto",
         height: "auto",
@@ -26,6 +26,9 @@ const useStyles = makeStyles<Theme>(theme => ({
     },
     WhiteActive: {
         backgroundColor: "#C4FEC4",
+    },
+    Highlighted: {
+        backgroundColor: "#9fdafc",
     },
 
     Square: {
@@ -63,6 +66,7 @@ const useStyles = makeStyles<Theme>(theme => ({
         margin: "0",
         marginBlockStart: "0",
         marginBlockEnd: "0",
+        userSelect: "none",
     },
 }));
 
@@ -71,7 +75,7 @@ const useStyles = makeStyles<Theme>(theme => ({
  * @param props includes boolean for color, id of the piece, coordinate (position, i.e. e4), clickfunction and reference to list of active squares
  * @returns 
  */
-export default function Square(props: { isWhite: boolean, id: string, coordinate: string, clickFunction: any, active: any }) {
+export default function Square(props: { isWhite: boolean, id: string, coordinate: string, clickFunction: any, active: any, highlight?: boolean}) {
 
     const classes = useStyles();
     /**
@@ -88,6 +92,7 @@ export default function Square(props: { isWhite: boolean, id: string, coordinate
         coordinate,
         clickFunction,
         active,
+        highlight,
     } = props;
 
     /**
@@ -118,13 +123,24 @@ export default function Square(props: { isWhite: boolean, id: string, coordinate
 
     }, [active]);
 
+    const Color = () => {
+        if (!activated && highlight) {
+            return classes.Highlighted;
+        }
+
+        if (isWhite) {
+            return activated ? classes.WhiteActive : classes.White;
+        }
+        return activated ? classes.BlackActive : classes.Black;
+    }
+
 
     /**
      * Returns HTML
      */
     if (isWhite) {
         return (
-            <Box className={`${classes.SquareContainer} ${activated ? classes.WhiteActive : classes.White}`} onClick={() => clickFunction("")}>
+            <Box className={`${classes.SquareContainer} ${Color()}`} onClick={() => clickFunction("")}>
                 <Box className={classes.Square}>
                     {id !== "--" ? <img src={PieceImageAdapter.getImageRef(id)}
                         alt={id}
@@ -137,7 +153,7 @@ export default function Square(props: { isWhite: boolean, id: string, coordinate
     }
     else {
         return (
-            <Box className={`${classes.SquareContainer} ${activated ? classes.BlackActive : classes.Black}`} onClick={() => clickFunction("")}>
+            <Box className={`${classes.SquareContainer} ${Color()}`} onClick={() => clickFunction("")}>
                 <Box className={classes.Square}>
                     {id !== "--" ? <img
                         src={PieceImageAdapter.getImageRef(id)}

--- a/src/Services/GameService.ts
+++ b/src/Services/GameService.ts
@@ -134,6 +134,10 @@ export default class GameService {
         this.hubConnection.send('AssignAI', gameId);
     }
 
+    sendPromotionChoice(gameId: string, pieceIdentifier: string): void {
+        this.hubConnection.send('PromotePiece', gameId, pieceIdentifier);
+    }
+
     async requestColors(gameId: string): Promise<Colors> {
         return this.hubConnection.invoke('RequestColors', gameId)
     }
@@ -173,6 +177,8 @@ export interface GameState {
     board: string[],
     boardSize: BoardSize,
     moves: Move[]
+    latestMoveFromIndex?: number,
+    latestMoveToIndex?: number,
 }
 
 export interface BoardSize {
@@ -183,6 +189,11 @@ export interface BoardSize {
 export interface Move {
     from: string,
     to: string[],
+}
+
+export interface PromotionOptions {
+    promotablePieces: string[],
+    player: "white" | "black",
 }
 
 
@@ -205,6 +216,8 @@ export enum GameEvents {
     GameVariantNotSet = "gameVariantNotSet",
     GameStarted = "gameStarted",
     Colors = "colors",
+    Promotion = "promotion",
+    Promoted = "promoted",
 }
 
 export enum Variant {


### PR DESCRIPTION
This PR adds the frontend functionality for selecting a piece when eligible for promotion. It achieves this with a new component called `PromotionSelector` which is added to the `MatchPage` component. It subscribes to a new event from the backend which lets us know when we should display the promotion selector as well as it's options.